### PR TITLE
Fix consume-records and consume-timeout CLI documentation

### DIFF
--- a/docs/CLI-Example.rst
+++ b/docs/CLI-Example.rst
@@ -159,9 +159,7 @@ consume
 ^^^^^^^
 
 An operation which receives messages from specified topics at
-specified brokers. Optional arguments, like consume-records or
-consume-timeout, are supported to refine the record list contained in
-the consumer operation result.
+specified brokers.
 
 +----------------------+----------------+
 | Mandatory Arguments  | Description    |
@@ -208,15 +206,14 @@ the consumer operation result.
 |                       | auto.offset.reset=earliest, |               |
 |                       | auto.commit.interval.ms=0   |               |
 +-----------------------+-----------------------------+---------------+
-| ``--consume-records`` | Maximum number of records   | 1 record      |
-|                       | to read within the          |               |
-|                       | specified                   |               |
-|                       | ``consume-timeout``.        |               |
+| ``--consume-records`` | Number of expected records  | 1 record      |
+|                       | to finish command line.     |               |
 |                       | CLI polls for new records   |               |
 |                       | until one of the following  |               |
 |                       | occurs:timeout has          |               |
-|                       | elapsed or maximum number   |               |
-|                       | of records were received.   |               |
+|                       | elapsed or number of records|               |
+|                       | received were greater than  |               |
+|                       | this value.                 |               |
 +-----------------------+-----------------------------+---------------+
 | ``--consume-timeout`` | Maximum time to wait for    | 15000         |
 |                       | receiving the specified     | milliseconds  |
@@ -225,7 +222,7 @@ the consumer operation result.
 |                       | until one of the following  |               |
 |                       | occurs:timeout has elapsed  |               |
 |                       | or number of received       |               |
-|                       | records reached             |               |
+|                       | records were greater than   |               |
 |                       | ``consume-records`` value.  |               |
 +-----------------------+-----------------------------+---------------+
 
@@ -238,8 +235,8 @@ example
     --operation consume \
     --from-topic <TOPIC_1,TOPIC_2,...,TOPIC_N> \
     --brokers <BROKER_1_IP:BROKER_1_PORT,BROKER_2_PORT:BROKER_2_PORT,...> \
-    --consume-timeout <CONSUME-TIMEOUT> \
-    --consume-records <CONSUME-RECORDS-NUMBER> \
+    --consume-timeout <CONSUME-TIMEOUT-TO-FINISH-CLI> \
+    --consume-records <CONSUME-RECORDS-NUMBER-TO-FINISH-CLI> \
     --tenant-group <TENANT-GROUP-NAME> \
     --cg <CONSUMER-GROUP>
     --config enable.auto.commit=true 

--- a/docs/CLI-Example.rst
+++ b/docs/CLI-Example.rst
@@ -214,12 +214,12 @@ specified brokers.
 |                       | received were greater than  |               |
 |                       | this value.                 |               |
 +-----------------------+-----------------------------+---------------+
-| ``--consume-timeout`` | Maximum time to wait for    | 15000         |
-|                       | receiving the specified     | milliseconds  |
-|                       | ``consume-records`` number. |               |
+| ``--consume-timeout`` | Maximum time the command    | 15000         |
+|                       | line waits for finishing    | milliseconds  |
+|                       | a consume operation.        |               |
 |                       | CLI polls for new records   |               |
 |                       | until one of the following  |               |
-|                       | occurs:timeout has elapsed  |               |
+|                       | occurs: timeout has elapsed |               |
 |                       | or number of received       |               |
 |                       | records were greater than   |               |
 |                       | ``consume-records`` value.  |               |

--- a/docs/CLI-Example.rst
+++ b/docs/CLI-Example.rst
@@ -209,7 +209,7 @@ specified brokers.
 |                       | to finish command line.     |               |
 |                       | CLI polls for new records   |               |
 |                       | until one of the following  |               |
-|                       | occurs:timeout has          |               |
+|                       | occurs: timeout has         |               |
 |                       | elapsed or number of records|               |
 |                       | received were greater than  |               |
 |                       | this value.                 |               |

--- a/docs/CLI-Example.rst
+++ b/docs/CLI-Example.rst
@@ -19,12 +19,11 @@ library with no arguments displays help information:
     --config [String: config]              The producer/consumer configuration    
                                              list: Example: linger.ms=1000,batch. 
                                              size=100000,compression.type=lz4     
-    --consume-records <Integer: consume-   Consume Poll expected records. Number  
-      records>                               of expected records.  (default: 1)   
-    --consume-timeout <Integer: consume-   Consume Poll Timeout. Time in ms that  
-      timeout>                               the consumer waits for new records   
-                                             during a consume operation.          
-                                             Optional parameter, if absent, it    
+    --consume-records <Integer: consume-   Number of expected records to finish
+      records>                               the command line.  (default: 1)
+    --consume-timeout <Integer: consume-   Max time the command line waits for
+      timeout>                               finishing a consumer operation.
+                                             Optional parameter, if absent, it
                                              defaults to 15000 ms. (default: 15000)
     --from-topic <String: from-topic>      Comma-separated topic name list to
                                              consume. Example: topic1,topic2,..., 

--- a/src/main/java/com/opendxl/databus/cli/CommandLineInterface.java
+++ b/src/main/java/com/opendxl/databus/cli/CommandLineInterface.java
@@ -120,8 +120,8 @@ public class CommandLineInterface {
 
         // Consumer config option spec represented as --consume-timeout command line
         final ArgumentAcceptingOptionSpec<Integer> consumeTimeoutOpt =
-                parser.accepts("consume-timeout", "Consume Poll Timeout. Time in ms that the consumer"
-                        + " waits for new records during a consume operation. "
+                parser.accepts("consume-timeout", "Max time the command line"
+                        + " waits for finishing a consume operation. "
                         + " Optional parameter, if absent, it defaults to 15000 ms.")
                         .withRequiredArg()
                         .ofType(Integer.class)
@@ -130,8 +130,8 @@ public class CommandLineInterface {
 
         // Consumer config option spec represented as --consume-records command line
         final ArgumentAcceptingOptionSpec<Integer> consumeRecordsOpt =
-                parser.accepts("consume-records", "Consume Poll expected records. "
-                        + "Number of expected records. ")
+                parser.accepts("consume-records", "Number of expected records to finish the"
+                        + " command line. ")
                         .withRequiredArg()
                         .ofType(Integer.class)
                         .describedAs("consume-records")


### PR DESCRIPTION
Fix consume-records and consume-timeout CLI documentation. It was not clear how these CLI arguments work. 