### PR TITLE
Use 1.7.29 version of slf4j-api dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.apache.commons:commons-configuration2:2.5'
     implementation 'commons-lang:commons-lang:2.6'
-    implementation 'org.slf4j:slf4j-api'
+    implementation 'org.slf4j:slf4j-api:1.7.29'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     testImplementation 'org.apache.kafka:kafka_2.12:2.3.0'
     testImplementation 'org.apache.zookeeper:zookeeper:3.4.14'

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.apache.commons:commons-configuration2:2.5'
     implementation 'commons-lang:commons-lang:2.6'
-    implementation 'org.slf4j:slf4j-api:1.7.29'
+    implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     testImplementation 'org.apache.kafka:kafka_2.12:2.3.0'
     testImplementation 'org.apache.zookeeper:zookeeper:3.4.14'


### PR DESCRIPTION
This change is to fix a Consumer Service **build warning**:

[WARNING] The POM for com.opendxl:dxldatabusclient:jar:2.3.0 is invalid, transitive dependencies (if any) will not be available: 1 problem was encountered while building the effective model for com.opendxl:dxldatabusclient:2.3.0
_[ERROR] 'dependencies.dependency.version' for org.slf4j:slf4j-api:jar is missing._ @
