### PR TITLE
Depcheck issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     implementation ('org.apache.kafka:kafka-streams:2.3.1') {
         exclude group: 'org.scala-lang', module: 'scala-reflect'
     }
+    implementation group: 'org.scala-lang', name: 'scala-reflect', version: '2.12.11'
     implementation 'org.apache.avro:avro:1.9.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.apache.commons:commons-configuration2:2.7'

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation ('org.apache.kafka:kafka-streams:2.3.1') {
         exclude group: 'org.scala-lang', module: 'scala-reflect'
     }
-    implementation group: 'org.scala-lang', name: 'scala-reflect', version: '2.12.11'
+    implementation 'org.scala-lang:scala-reflect:2.12.11'
     implementation 'org.apache.avro:avro:1.9.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.apache.commons:commons-configuration2:2.7'
@@ -73,7 +73,7 @@ dependencies {
     testImplementation('org.apache.kafka:kafka_2.12:2.3.1') {
         exclude group: 'org.scala-lang', module: 'scala-reflect'
     }
-    testImplementation group: 'org.scala-lang', name: 'scala-reflect', version: '2.12.11'
+    testImplementation 'org.scala-lang:scala-reflect:2.12.11'
     testImplementation 'org.apache.zookeeper:zookeeper:3.5.5'
     testImplementation('io.netty:netty-all:4.1.43.Final') {
         force = true
@@ -84,7 +84,7 @@ dependencies {
     kafkaInMemory ('org.apache.kafka:kafka_2.12:2.3.1') {
         exclude group: 'org.scala-lang', module: 'scala-reflect'
     }
-    kafkaInMemory group: 'org.scala-lang', name: 'scala-reflect', version: '2.12.11'
+    kafkaInMemory 'org.scala-lang:scala-reflect:2.12.11'
     kafkaInMemory 'commons-io:commons-io:2.6'
 
     // This following section mitigates OWASP vulnerabilities report.

--- a/build.gradle
+++ b/build.gradle
@@ -57,15 +57,22 @@ configurations {
 }
 
 dependencies {
-    implementation 'org.apache.kafka:kafka-clients:2.3.1'
-    implementation 'org.apache.kafka:kafka-streams:2.3.1'
+    implementation ('org.apache.kafka:kafka-clients:2.3.1') {
+        exclude group: 'org.scala-lang', module: 'scala-reflect'
+    }
+    implementation ('org.apache.kafka:kafka-streams:2.3.1') {
+        exclude group: 'org.scala-lang', module: 'scala-reflect'
+    }
     implementation 'org.apache.avro:avro:1.9.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.apache.commons:commons-configuration2:2.7'
     implementation 'commons-lang:commons-lang:2.6'
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
-    testImplementation 'org.apache.kafka:kafka_2.12:2.3.1'
+    testImplementation('org.apache.kafka:kafka_2.12:2.3.1') {
+        exclude group: 'org.scala-lang', module: 'scala-reflect'
+    }
+    testImplementation group: 'org.scala-lang', name: 'scala-reflect', version: '2.12.11'
     testImplementation 'org.apache.zookeeper:zookeeper:3.5.5'
     testImplementation('io.netty:netty-all:4.1.43.Final') {
         force = true
@@ -73,7 +80,10 @@ dependencies {
     testImplementation 'commons-io:commons-io:2.6'
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
-    kafkaInMemory 'org.apache.kafka:kafka_2.12:2.3.1'
+    kafkaInMemory ('org.apache.kafka:kafka_2.12:2.3.1') {
+        exclude group: 'org.scala-lang', module: 'scala-reflect'
+    }
+    kafkaInMemory group: 'org.scala-lang', name: 'scala-reflect', version: '2.12.11'
     kafkaInMemory 'commons-io:commons-io:2.6'
 
     // This following section mitigates OWASP vulnerabilities report.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.5.1-SNAPSHOT
+version=2.5.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.5.0-SNAPSHOT
+version=2.5.1-SNAPSHOT


### PR DESCRIPTION
We are fixing this Vulnerability:

scala-reflect-2.12.8.jar (pkg:maven/org.scala-lang/scala-reflect@2.12.8, cpe:2.3:a:scala-lang:scala:2.12.8:*:*:*:*:*:*:*) : CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')